### PR TITLE
Update repo path of golint

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -5,7 +5,7 @@
       "Commit": "45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2"
     },
     {
-      "Repository": "github.com/golang/lint/golint",
+      "Repository": "golang.org/x/lint/golint",
       "Commit": "06c8688daad7faa9da5a0c2f163a3d14aac986ca"
     },
     {


### PR DESCRIPTION
Currently `make retool` fails:

```
$ make retool
retool sync
retool: downloading github.com/golang/dep/cmd/dep
retool: setting version for github.com/golang/dep/cmd/dep
retool: downloading github.com/golang/lint/golint
retool: fatal err: execution error on "go get -d github.com/golang/lint/golint": package github.com/golang/lint/golint: code in directory /home/user/go/src/github.com/promhippie/hcloud_exporter/_tools/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
: failed to 'go get' tool: exit status 1
make: *** [Makefile:145: retool] Error 1
```

According to https://github.com/golang/lint/issues/415 the path was changed in February 2018 https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3.

This PR simply updates the path and should not change any functionality.