### PR TITLE
Add pricing collector

### DIFF
--- a/cmd/hcloud_exporter/main.go
+++ b/cmd/hcloud_exporter/main.go
@@ -93,6 +93,13 @@ func main() {
 				Destination: &cfg.Collector.Images,
 			},
 			&cli.BoolFlag{
+				Name:        "collector.pricing",
+				Value:       true,
+				Usage:       "Enable collector for pricing",
+				EnvVars:     []string{"HCLOUD_EXPORTER_COLLECTOR_PRICING"},
+				Destination: &cfg.Collector.Pricing,
+			},
+			&cli.BoolFlag{
 				Name:        "collector.servers",
 				Value:       true,
 				Usage:       "Enable collector for servers",

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -65,6 +65,9 @@ HCLOUD_EXPORTER_COLLECTOR_FLOATING_IPS
 HCLOUD_EXPORTER_COLLECTOR_IMAGES
 : Enable collector for images, defaults to `true`
 
+HCLOUD_EXPORTER_COLLECTOR_PRICING
+: Enable collector for pricing information, defaults to `true`
+
 HCLOUD_EXPORTER_COLLECTOR_SERVERS
 : Enable collector for servers, defaults to `true`
 
@@ -96,6 +99,18 @@ hcloud_image_created_timestamp
 
 hcloud_image_deprecated_timestamp
 : Timestamp when the image will be deprecated, 0 if not deprecated
+
+hcloud_pricing_floating_ip
+: The cost of one floating IP per month
+
+hcloud_pricing_image
+: The cost of an image per GB/month
+
+hcloud_pricing_server_backup
+: Will increase base server costs by specific percentage if server backups are enabled
+
+hcloud_pricing_traffic
+: The cost of additional traffic per TB
 
 hcloud_server_running
 : If 1 the server is running, 0 otherwise

--- a/pkg/action/server.go
+++ b/pkg/action/server.go
@@ -131,6 +131,16 @@ func handler(cfg *config.Config, logger log.Logger, client *hcloud.Client) *chi.
 		))
 	}
 
+	if cfg.Collector.Pricing {
+		r.MustRegister(exporter.NewPricingCollector(
+			logger,
+			client,
+			requestFailures,
+			requestDuration,
+			cfg.Target.Timeout,
+		))
+	}
+
 	if cfg.Collector.Servers {
 		r.MustRegister(exporter.NewServerCollector(
 			logger,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Target struct {
 type Collector struct {
 	FloatingIPs bool
 	Images      bool
+	Pricing     bool
 	Servers     bool
 	SSHKeys     bool
 }

--- a/pkg/exporter/pricing.go
+++ b/pkg/exporter/pricing.go
@@ -1,0 +1,229 @@
+package exporter
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PricingCollector collects metrics about the prices for additional products: Image, FloatingIP, Traffic and ServerBackup.
+type PricingCollector struct {
+	client   *hcloud.Client
+	logger   log.Logger
+	failures *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+	timeout  time.Duration
+
+	Image        *prometheus.Desc
+	FloatingIP   *prometheus.Desc
+	Traffic      *prometheus.Desc
+	ServerBackup *prometheus.Desc
+}
+
+// NewPricingCollector returns a new PricingCollector.
+func NewPricingCollector(logger log.Logger, client *hcloud.Client, failures *prometheus.CounterVec, duration *prometheus.HistogramVec, timeout time.Duration) *PricingCollector {
+	failures.WithLabelValues("pricing").Add(0)
+
+	labels := []string{"currency", "vat"}
+	return &PricingCollector{
+		client:   client,
+		logger:   log.With(logger, "collector", "pricing"),
+		failures: failures,
+		duration: duration,
+		timeout:  timeout,
+
+
+		Image: prometheus.NewDesc(
+			"hcloud_pricing_image",
+			"The cost of an image per GB/month",
+			labels,
+			nil,
+		),
+		FloatingIP: prometheus.NewDesc(
+			"hcloud_pricing_floating_ip",
+			"The cost of one floating IP per month",
+			labels,
+			nil,
+		),
+		Traffic: prometheus.NewDesc(
+			"hcloud_pricing_traffic",
+			"The cost of additional traffic per TB",
+			labels,
+			nil,
+		),
+		ServerBackup: prometheus.NewDesc(
+			"hcloud_pricing_server_backup",
+			"Will increase base server costs by specific percentage if server backups are enabled",
+			nil,
+			nil,
+		),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics collected by this Collector.
+func (c *PricingCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.Image
+	ch <- c.FloatingIP
+	ch <- c.Traffic
+	ch <- c.ServerBackup
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *PricingCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	now := time.Now()
+	pricing, _, err := c.client.Pricing.Get(ctx)
+	c.duration.WithLabelValues("pricing").Observe(time.Since(now).Seconds())
+
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to fetch pricing",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	level.Debug(c.logger).Log(
+		"msg", "Fetched pricing",
+	)
+
+	imageGross, err := strconv.ParseFloat(pricing.Image.PerGBMonth.Gross, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse image costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	imageNet, err := strconv.ParseFloat(pricing.Image.PerGBMonth.Net, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse image costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Image,
+		prometheus.GaugeValue,
+		imageGross,
+		pricing.Image.PerGBMonth.Currency,
+		"gross",
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Image,
+		prometheus.GaugeValue,
+		imageNet,
+		pricing.Image.PerGBMonth.Currency,
+		"net",
+	)
+
+	floatingIPGross, err := strconv.ParseFloat(pricing.FloatingIP.Monthly.Gross, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse floating IP costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	floatingIPNet, err := strconv.ParseFloat(pricing.FloatingIP.Monthly.Net, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse floating IP costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FloatingIP,
+		prometheus.GaugeValue,
+		floatingIPGross,
+		pricing.FloatingIP.Monthly.Currency,
+		"gross",
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FloatingIP,
+		prometheus.GaugeValue,
+		floatingIPNet,
+		pricing.FloatingIP.Monthly.Currency,
+		"net",
+	)
+
+	trafficGross, err := strconv.ParseFloat(pricing.Traffic.PerTB.Gross, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse traffic costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	trafficNet, err := strconv.ParseFloat(pricing.Traffic.PerTB.Net, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse traffic costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Traffic,
+		prometheus.GaugeValue,
+		trafficGross,
+		pricing.Traffic.PerTB.Currency,
+		"gross",
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Traffic,
+		prometheus.GaugeValue,
+		trafficNet,
+		pricing.Traffic.PerTB.Currency,
+		"net",
+	)
+
+	serverBackup, err := strconv.ParseFloat(pricing.ServerBackup.Percentage, 64)
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to parse server backup costs",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("pricing").Inc()
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ServerBackup,
+		prometheus.GaugeValue,
+		serverBackup/100,
+	)
+}

--- a/tools.json
+++ b/tools.json
@@ -5,7 +5,7 @@
       "Commit": "45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2"
     },
     {
-      "Repository": "github.com/golang/lint/golint",
+      "Repository": "golang.org/x/lint/golint",
       "Commit": "06c8688daad7faa9da5a0c2f163a3d14aac986ca"
     },
     {


### PR DESCRIPTION
As a preparation to make #15 possible I implemented a pricing collector.
It exposes the following metrics including gross and net prices:

* hcloud_pricing_floating_ip
  The cost of one floating IP per month

* hcloud_pricing_image
  The cost of an image per GB/month

* hcloud_pricing_server_backup
  Will increase base server costs by specific percentage if server backups are enabled

* hcloud_pricing_traffic
  The cost of additional traffic per TB

The Hetzner cloud API also exposes prices for all server types in all
regions. It would be possible to collect those as well but it would
produce a lot of data with limited use. (Every server type is available
with two different storage technologies and in three different
regions.) If someone needs all thoses prices it should be easy to add in
the future.

Example output:

```
# HELP hcloud_pricing_floating_ip The cost of one floating IP per month
# TYPE hcloud_pricing_floating_ip gauge
hcloud_pricing_floating_ip{currency="EUR",vat="gross"} 1.19
hcloud_pricing_floating_ip{currency="EUR",vat="net"} 1
# HELP hcloud_pricing_image The cost of Image per GB/month
# TYPE hcloud_pricing_image gauge
hcloud_pricing_image{currency="EUR",vat="gross"} 0.0119
hcloud_pricing_image{currency="EUR",vat="net"} 0.01
# HELP hcloud_pricing_server_backup Will increase base server costs by specific percentage if server backups are enabled
# TYPE hcloud_pricing_server_backup gauge
hcloud_pricing_server_backup 0.2
# HELP hcloud_pricing_traffic The cost of additional traffic per TB
# TYPE hcloud_pricing_traffic gauge
hcloud_pricing_traffic{currency="EUR",vat="gross"} 1.19
hcloud_pricing_traffic{currency="EUR",vat="net"} 1
```