### PR TITLE
Export net and gross values for hcloud_server_price_* metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.0] - 2019-03-12
+
+### Added
+
+* Added a `vat` label (`gross` or `net`) to the `hcloud_server_price` metric. Depending on the setup this can be a breaking change and it may be necessary to adjust some dashboards and alerting rules.
+
 ## [0.2.0] - 2019-03-11
 
 ### Added


### PR DESCRIPTION
Similar to the new hcloud_pricing metrics this change exports the hcloud_server_price metrics with gross and net values.

This could break dashboards and alerts that are based on the sum of all hcloud_server_price_monthly metrics and similar stuff. But I think it is very useful to have both values available.