### PR TITLE
Adds a helm chart 

### DIFF
--- a/charts/hcloud-exporter/.helmignore
+++ b/charts/hcloud-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hcloud-exporter/Chart.yaml
+++ b/charts/hcloud-exporter/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: hcloud-exporter
+description: A Helm chart for Hetzner cloud Prometheus exporter
+type: application
+version: 0.0.1
+appVersion: "1.0.0"
+home: https://github.com/lablabs/hcloud-exporter
+icon: https://www.hetzner.com/assets/Uploads/icon-circle-cloud.svg
+keywords:
+  - prometheus
+  - hcloud
+  - monitoring
+sources:
+  - https://github.com/promhippie/hcloud_exporter
+maintainers:
+  - name: erwinsteffens
+engine: gotpl
+annotations:
+  artifacthub.io/changes: |
+    - Initial helm chart

--- a/charts/hcloud-exporter/templates/_helpers.tpl
+++ b/charts/hcloud-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hcloud-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hcloud-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hcloud-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hcloud-exporter.labels" -}}
+helm.sh/chart: {{ include "hcloud-exporter.chart" . }}
+{{ include "hcloud-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hcloud-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hcloud-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hcloud-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hcloud-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/hcloud-exporter/templates/deployment.yaml
+++ b/charts/hcloud-exporter/templates/deployment.yaml
@@ -1,0 +1,124 @@
+{{- if and .Values.config.token .Values.config.tokenSecret -}}
+{{ fail (printf "ERROR: only one of .Values.config.token or .Values.config.tokenSecret must be defined") }}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hcloud-exporter.fullname" . }}
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "hcloud-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hcloud-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hcloud-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            {{- if .Values.config.logLevel }}
+            - name: HCLOUD_EXPORTER_LOG_LEVEL
+              value: {{ .Values.config.logLevel }}
+            {{- end }}
+            {{- if .Values.config.logPretty }}
+            - name: HCLOUD_EXPORTER_LOG_PRETTY
+              value: "{{ .Values.config.logPretty }}"
+            {{- end }}
+            {{- if .Values.config.requestTimeout }}
+            - name: HCLOUD_EXPORTER_REQUEST_TIMEOUT
+              value: {{ .Values.config.requestTimeout }}
+            {{- end }}
+            {{- if .Values.config.collect.floatingIps }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_FLOATING_IPS
+              value: "{{ .Values.config.collect.floatingIps }}"
+            {{- end }}
+            {{- if .Values.config.collect.images }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_IMAGES
+              value: "{{ .Values.config.collect.images }}"
+            {{- end }}
+            {{- if .Values.config.collect.pricing }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_PRICING
+              value: "{{ .Values.config.collect.pricing }}"
+            {{- end }}
+            {{- if .Values.config.collect.servers }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_SERVERS
+              value: "{{ .Values.config.collect.servers }}"
+            {{- end }}
+            {{- if .Values.config.collect.sshKeys }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_SSH_KEYS
+              value: "{{ .Values.config.collect.sshKeys }}"
+            {{- end }}
+            {{- if .Values.config.collect.volumes }}
+            - name: HCLOUD_EXPORTER_COLLECTOR_VOLUMES
+              value: "{{ .Values.config.collect.volumes }}"
+            {{- end }}
+            {{- range $key, $value := .Values.extraEnvSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "Must specify secret!" $value.secret }}
+                  key: {{ required "Must specify key!" $value.key }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          envFrom:
+          {{- if .Values.config.tokenSecret }}
+          - secretRef:
+              name: {{ .Values.tokenSecret }}
+          {{- else }}
+          - secretRef:
+              name: {{ template "hcloud-exporter.fullname" . }}
+          {{- end }}
+          {{- if .Values.envFromSecret }}
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9501
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/hcloud-exporter/templates/secret.yaml
+++ b/charts/hcloud-exporter/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not (or .Values.config.tokenSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "hcloud-exporter.fullname" . }}
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+type: Opaque
+data:
+  HCLOUD_EXPORTER_TOKEN: {{ .Values.config.token | b64enc }}
+{{- end -}}

--- a/charts/hcloud-exporter/templates/service.yaml
+++ b/charts/hcloud-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hcloud-exporter.fullname" . }}
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "hcloud-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/hcloud-exporter/templates/serviceaccount.yaml
+++ b/charts/hcloud-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hcloud-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/hcloud-exporter/templates/servicemonitor.yaml
+++ b/charts/hcloud-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
+  name: {{ template "hcloud-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: http
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+  jobLabel: {{ template "hcloud-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "hcloud-exporter.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hcloud-exporter/templates/tests/test-connection.yaml
+++ b/charts/hcloud-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "hcloud-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "hcloud-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "hcloud-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/hcloud-exporter/values.yaml
+++ b/charts/hcloud-exporter/values.yaml
@@ -1,0 +1,119 @@
+# Default values for hcloud-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: promhippie/hcloud-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+config:
+  token: 
+  tokenSecret: 
+  logLevel: "info"
+  logPretty: true
+  requestTimeout: "5s"
+  collect:
+    floatingIps: true
+    images: true
+    pricing: true
+    servers: true
+    sshKeys: true
+    volumes: true
+
+## Extra environment variables that will be passed into the exporter pod
+## example:
+## env:
+##   KEY_1: value1
+##   KEY_2: value2
+env: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""
+
+## A list of environment variables from secret refs that will be passed into the exporter pod
+## example:
+## This will set ${HCLOUD_EXPORTER_TOKEN} to the 'password' key from the 'my-secret' secret
+## extraEnvSecrets:
+##   HCLOUD_EXPORTER_TOKEN:
+##     secret: my-secret
+##     key: password
+extraEnvSecrets: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9501
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed, if empty namespace will be .Release.Namespace
+  namespace: ""
+  # Service monitor labels
+  labels: {}
+  # Set how frequently Prometheus should scrape
+  interval: 30s
+  # Set path to redis-exporter telemtery-path
+  telemetryPath: /metrics
+  # Set timeout for scrape
+  timeout: 10s
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  targetLabels: []
+  metricRelabelings: []
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -46,9 +46,8 @@ services:
     image: promhippie/hcloud-exporter:latest
     restart: always
     environment:
-      - GITHUB_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
-      - GITHUB_EXPORTER_LOG_PRETTY=true
-      - GITHUB_EXPORTER_ORG=promhippie
+      - HCLOUD_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
+      - HCLOUD_EXPORTER_LOG_PRETTY=true
 {{< / highlight >}}
 
 Since our `latest` Docker tag always refers to the `master` branch of the Git repository you should always use some fixed version. You can see all available tags at our [DockerHub repository](https://hub.docker.com/r/promhippie/hcloud-exporter/tags/), there you will see that we also provide a manifest, you can easily start the exporter on various architectures without any change to the image name. You should apply a change like this to the `docker-compose.yml`:
@@ -59,9 +58,8 @@ Since our `latest` Docker tag always refers to the `master` branch of the Git re
 +   image: promhippie/hcloud_exporter:1.0.0
     restart: always
     environment:
-      - GITHUB_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
-      - GITHUB_EXPORTER_LOG_PRETTY=true
-      - GITHUB_EXPORTER_ORG=promhippie
+      - HCLOUD_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
+      - HCLOUD_EXPORTER_LOG_PRETTY=true
 {{< / highlight >}}
 
 If you want to access the exporter directly you should bind it to a local port, otherwise only [Prometheus](https://prometheus.io) will have access to the exporter. For debugging purpose or just to discover all available metrics directly you can apply this change to your `docker-compose.yml`, after that you can access it directly at [http://localhost:9501/metrics](http://localhost:9501/metrics):
@@ -73,9 +71,8 @@ If you want to access the exporter directly you should bind it to a local port, 
 +   ports:
 +     - 127.0.0.1:9501:9501
     environment:
-      - GITHUB_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
-      - GITHUB_EXPORTER_LOG_PRETTY=true
-      - GITHUB_EXPORTER_ORG=promhippie
+      - HCLOUD_EXPORTER_TOKEN=bldyecdtysdahs76ygtbw51w3oeo6a4cvjwoitmb
+      - HCLOUD_EXPORTER_LOG_PRETTY=true
 {{< / highlight >}}
 
 Finally the exporter should be configured fine, let's start this stack with [docker-compose](https://docs.docker.com/compose/), you just need to execute `docker-compose up` within the directory where you have stored the `prometheus.yml` and `docker-compose.yml`.


### PR DESCRIPTION
We are using this Helm chart to deploy the exporter to Kubernetes. I am creating this PR because maybe it can be of value to this project?

It would be great if we could create a charts repository at https://github.com/promhippie/charts, so we can maybe at multiple charts in the future and publish them at the ArtifactHUB (https://artifacthub.io/).