### PR TITLE
New Collector: Server Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The following sections list the changes for unreleased.
 ## Summary
 
  * Chg #53: Integrate standard web config
+ * Chg #67: Add collector for server metrics
 
 ## Details
 
@@ -15,6 +16,14 @@ The following sections list the changes for unreleased.
    you check out the documentation.
 
    https://github.com/promhippie/hcloud_exporter/issues/53
+
+  * Change #67:Add collector for server metrics
+
+   Hetzner Cloud collects basic metrics on the hypervisor-level for each server. We've added a
+   new collector which scrapes the latest available metric point for each running server. It is
+   enabled by default.
+
+   https://github.com/promhippie/hcloud_exporter/pull/67
 
 
 # Changelog for 1.1.0

--- a/hack/generate-metrics-docs.go
+++ b/hack/generate-metrics-docs.go
@@ -46,6 +46,11 @@ func main() {
 
 	collectors = append(
 		collectors,
+		exporter.NewServerMetricsCollector(nil, nil, nil, nil, config.Load().Target).Metrics()...,
+	)
+
+	collectors = append(
+		collectors,
 		exporter.NewSSHKeyCollector(nil, nil, nil, nil, config.Load().Target).Metrics()...,
 	)
 

--- a/pkg/action/server.go
+++ b/pkg/action/server.go
@@ -158,6 +158,20 @@ func handler(cfg *config.Config, logger log.Logger, client *hcloud.Client) *chi.
 		))
 	}
 
+	if cfg.Collector.ServerMetrics {
+		level.Debug(logger).Log(
+			"msg", "Server metrics collector registered",
+		)
+
+		registry.MustRegister(exporter.NewServerMetricsCollector(
+			logger,
+			client,
+			requestFailures,
+			requestDuration,
+			cfg.Target,
+		))
+	}
+
 	if cfg.Collector.LoadBalancers {
 		level.Debug(logger).Log(
 			"msg", "Load balancer collector registered",

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -148,6 +148,13 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Collector.Servers,
 		},
 		&cli.BoolFlag{
+			Name:        "collector.server-metrics",
+			Value:       true,
+			Usage:       "Enable collector for server metrics",
+			EnvVars:     []string{"HCLOUD_EXPORTER_COLLECTOR_SERVER_METRICS"},
+			Destination: &cfg.Collector.ServerMetrics,
+		},
+		&cli.BoolFlag{
 			Name:        "collector.load-balancers",
 			Value:       true,
 			Usage:       "Enable collector for load balancers",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type Collector struct {
 	Images        bool
 	Pricing       bool
 	Servers       bool
+	ServerMetrics bool
 	LoadBalancers bool
 	SSHKeys       bool
 	Volumes       bool

--- a/pkg/exporter/server-metrics.go
+++ b/pkg/exporter/server-metrics.go
@@ -1,0 +1,297 @@
+package exporter
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/promhippie/hcloud_exporter/pkg/config"
+)
+
+// ServerMetricsCollector collects the servers metrics.
+type ServerMetricsCollector struct {
+	client   *hcloud.Client
+	logger   log.Logger
+	failures *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+	config   config.Target
+
+	CPU           *prometheus.Desc
+	DiskReadIops  *prometheus.Desc
+	DiskWriteIops *prometheus.Desc
+	DiskReadBps   *prometheus.Desc
+	DiskWriteBps  *prometheus.Desc
+	NetworkInPps  *prometheus.Desc
+	NetworkOutPps *prometheus.Desc
+	NetworkInBps  *prometheus.Desc
+	NetworkOutBps *prometheus.Desc
+}
+
+// NewServerMetricsCollector returns a new ServerMetricsCollector.
+func NewServerMetricsCollector(logger log.Logger, client *hcloud.Client, failures *prometheus.CounterVec, duration *prometheus.HistogramVec, cfg config.Target) *ServerMetricsCollector {
+	if failures != nil {
+		failures.WithLabelValues("server-metrics").Add(0)
+	}
+
+	labels := []string{"id", "name", "datacenter"}
+	return &ServerMetricsCollector{
+		client:   client,
+		logger:   log.With(logger, "collector", "server-metrics"),
+		failures: failures,
+		duration: duration,
+		config:   cfg,
+
+		CPU: prometheus.NewDesc(
+			"hcloud_server_metrics_cpu",
+			"Server CPU usage metric",
+			labels,
+			nil,
+		),
+
+		DiskReadIops: prometheus.NewDesc(
+			"hcloud_server_metrics_disk_read_iops",
+			"Server disk read iop/s metric",
+			labels,
+			nil,
+		),
+
+		DiskWriteIops: prometheus.NewDesc(
+			"hcloud_server_metrics_disk_write_iops",
+			"Server disk write iop/s metric",
+			labels,
+			nil,
+		),
+
+		DiskReadBps: prometheus.NewDesc(
+			"hcloud_server_metrics_disk_read_bps",
+			"Server disk read bytes/s metric",
+			labels,
+			nil,
+		),
+
+		DiskWriteBps: prometheus.NewDesc(
+			"hcloud_server_metrics_disk_write_bps",
+			"Server disk write bytes/s metric",
+			labels,
+			nil,
+		),
+
+		NetworkInPps: prometheus.NewDesc(
+			"hcloud_server_metrics_network_in_pps",
+			"Server network incoming packets/s metric",
+			labels,
+			nil,
+		),
+
+		NetworkOutPps: prometheus.NewDesc(
+			"hcloud_server_metrics_network_out_pps",
+			"Server network outgoing packets/s metric",
+			labels,
+			nil,
+		),
+
+		NetworkInBps: prometheus.NewDesc(
+			"hcloud_server_metrics_network_in_bps",
+			"Server network incoming bytes/s metric",
+			labels,
+			nil,
+		),
+
+		NetworkOutBps: prometheus.NewDesc(
+			"hcloud_server_metrics_network_out_bps",
+			"Server network outgoing bytes/s metric",
+			labels,
+			nil,
+		),
+	}
+}
+
+// Metrics simply returns the list metric descriptors for generating a documentation.
+func (c *ServerMetricsCollector) Metrics() []*prometheus.Desc {
+	return []*prometheus.Desc{
+
+		c.CPU,
+		c.DiskReadIops,
+		c.DiskWriteIops,
+		c.DiskReadBps,
+		c.DiskWriteBps,
+		c.NetworkInPps,
+		c.NetworkOutPps,
+		c.NetworkInBps,
+		c.NetworkOutBps,
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics collected by this Collector.
+func (c *ServerMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+
+	ch <- c.CPU
+	ch <- c.DiskReadIops
+	ch <- c.DiskWriteIops
+	ch <- c.DiskReadBps
+	ch <- c.DiskWriteBps
+	ch <- c.NetworkInPps
+	ch <- c.NetworkOutPps
+	ch <- c.NetworkInBps
+	ch <- c.NetworkOutBps
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *ServerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.Timeout)
+	defer cancel()
+
+	now := time.Now()
+	opts := hcloud.ServerListOpts{
+		Status: []hcloud.ServerStatus{
+			hcloud.ServerStatusRunning,
+		},
+	}
+	servers, _, err := c.client.Server.List(ctx, opts)
+
+	level.Debug(c.logger).Log(
+		"msg", "Fetched online servers",
+		"count", len(servers),
+	)
+
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "Failed to fetch servers",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("server-metrics").Inc()
+		return
+	}
+
+	now = time.Now()
+
+	type empty struct{}
+	sem := make(chan empty, len(servers))
+
+	for _, server := range servers {
+
+		labels := []string{
+			strconv.Itoa(server.ID),
+			server.Name,
+			server.Datacenter.Name,
+		}
+
+		go func(c *ServerMetricsCollector, ctx context.Context, server *hcloud.Server) {
+
+			metricsOpts := hcloud.ServerGetMetricsOpts{
+				Types: []hcloud.ServerMetricType{
+					hcloud.ServerMetricCPU,
+					hcloud.ServerMetricDisk,
+					hcloud.ServerMetricNetwork,
+				},
+				Start: time.Now(),
+				End:   time.Now(),
+			}
+
+			metrics, _, err := c.client.Server.GetMetrics(ctx, server, metricsOpts)
+
+			sem <- empty{}
+
+			if err != nil {
+				level.Error(c.logger).Log(
+					"msg", "Failed to fetch server metrics",
+					"err", err,
+				)
+
+				c.failures.WithLabelValues("server-metrics").Inc()
+				return
+			}
+
+			CPU, _ := strconv.ParseFloat(metrics.TimeSeries["cpu"][0].Value, 64)
+			DiskReadIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.read"][0].Value, 64)
+			DiskWriteIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.write"][0].Value, 64)
+			DiskReadBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.read"][0].Value, 64)
+			DiskWriteBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.write"][0].Value, 64)
+			NetworkInPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.in"][0].Value, 64)
+			NetworkOutPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.out"][0].Value, 64)
+			NetworkInBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.in"][0].Value, 64)
+			NetworkOutBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.out"][0].Value, 64)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.CPU,
+				prometheus.GaugeValue,
+				CPU,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskReadIops,
+				prometheus.GaugeValue,
+				DiskReadIops,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskWriteIops,
+				prometheus.GaugeValue,
+				DiskWriteIops,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskReadBps,
+				prometheus.GaugeValue,
+				DiskReadBps,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskWriteBps,
+				prometheus.GaugeValue,
+				DiskWriteBps,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkInPps,
+				prometheus.GaugeValue,
+				NetworkInPps,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkOutPps,
+				prometheus.GaugeValue,
+				NetworkOutPps,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkInBps,
+				prometheus.GaugeValue,
+				NetworkInBps,
+				labels...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkOutBps,
+				prometheus.GaugeValue,
+				NetworkOutBps,
+				labels...,
+			)
+		}(c, ctx, server)
+
+	}
+
+	// Wait for all go-routines to signal finished metrics fetch
+	for i := 0; i < len(servers); i++ {
+		<-sem
+	}
+
+	c.duration.WithLabelValues("server-metrics").Observe(time.Since(now).Seconds())
+	level.Debug(c.logger).Log(
+		"msg", "Fetched server metrics",
+		"count", len(servers),
+	)
+
+}

--- a/pkg/exporter/server-metrics.go
+++ b/pkg/exporter/server-metrics.go
@@ -57,13 +57,20 @@ func NewServerMetricsCollector(logger log.Logger, client *hcloud.Client, failure
 		DiskReadIops: prometheus.NewDesc(
 			"hcloud_server_metrics_disk_read_iops",
 			"Server disk read iop/s metric",
-			labels,
+			diskLabels,
 			nil,
 		),
 
 		DiskWriteIops: prometheus.NewDesc(
 			"hcloud_server_metrics_disk_write_iops",
 			"Server disk write iop/s metric",
+			diskLabels,
+			nil,
+		),
+
+		DiskReadBps: prometheus.NewDesc(
+			"hcloud_server_metrics_disk_read_bps",
+			"Server disk write bytes/s metric",
 			diskLabels,
 			nil,
 		),
@@ -202,19 +209,8 @@ func (c *ServerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// Hetzner currently only provides a single 0-indexed timeseries for each metric, so it's simply hardcoded.
 			// If Hetzner ever extends this, determining the amount of returned timeseries would be better.
-			diskLabels := []string{
-				strconv.Itoa(server.ID),
-				server.Name,
-				server.Datacenter.Name,
-				"0",
-			}
-
-			networkLabels := []string{
-				strconv.Itoa(server.ID),
-				server.Name,
-				server.Datacenter.Name,
-				"0",
-			}
+			diskLabels := append(labels, "0")
+			networkLabels := append(labels, "0")
 
 			CPU, _ := strconv.ParseFloat(metrics.TimeSeries["cpu"][0].Value, 64)
 			DiskReadIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.read"][0].Value, 64)

--- a/pkg/exporter/server-metrics.go
+++ b/pkg/exporter/server-metrics.go
@@ -163,8 +163,6 @@ func (c *ServerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	now = time.Now()
-
 	type empty struct{}
 	sem := make(chan empty, len(servers))
 


### PR DESCRIPTION
Hetzner Cloud collects basic metrics on the hypervisor-level for each
server. This adds a new collector that scrapes the latest available
metric point for each running server.

Unfortunately, Hetzner only exposes Gauge Type metrics, whereas
traditionally you would prefer Counter Type metrics for disk and
network. Nonetheless, this should still be useful.

The selectors for the reported metrics are hard-coded with the '.0.'
part. One could assume, that this indicates an additional metrics
dimension, but the Hetzner Cloud API documentation indicates that there
will always be just this one variant. Tests with additional volumes
attached showed that this remains true.

Signed-off-by: Jan Koppe <post@jankoppe.de>