### PR TITLE
#72 Fix out of range slice access in server metrics

### DIFF
--- a/pkg/exporter/server_metrics.go
+++ b/pkg/exporter/server_metrics.go
@@ -201,78 +201,95 @@ func (c *ServerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		diskLabels := append(labels, "0")
 		networkLabels := append(labels, "0")
 
-		cpuUsage, _ := strconv.ParseFloat(metrics.TimeSeries["cpu"][0].Value, 64)
-		diskReadIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.read"][0].Value, 64)
-		diskWriteIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.write"][0].Value, 64)
-		diskReadBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.read"][0].Value, 64)
-		diskWriteBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.write"][0].Value, 64)
-		networkInPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.in"][0].Value, 64)
-		networkOutPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.out"][0].Value, 64)
-		networkInBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.in"][0].Value, 64)
-		networkOutBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.out"][0].Value, 64)
+		if len(metrics.TimeSeries["cpu"]) > 0 {
+			cpuUsage, _ := strconv.ParseFloat(metrics.TimeSeries["cpu"][len(metrics.TimeSeries["cpu"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.CPU,
+				prometheus.GaugeValue,
+				cpuUsage,
+				labels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.CPU,
-			prometheus.GaugeValue,
-			cpuUsage,
-			labels...,
-		)
+		if len(metrics.TimeSeries["disk.0.iops.read"]) > 0 {
+			diskReadIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.read"][len(metrics.TimeSeries["disk.0.iops.read"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskReadIops,
+				prometheus.GaugeValue,
+				diskReadIops,
+				diskLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.DiskReadIops,
-			prometheus.GaugeValue,
-			diskReadIops,
-			diskLabels...,
-		)
+		if len(metrics.TimeSeries["disk.0.iops.write"]) > 0 {
+			diskWriteIops, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.iops.write"][len(metrics.TimeSeries["disk.0.iops.write"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskWriteIops,
+				prometheus.GaugeValue,
+				diskWriteIops,
+				diskLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.DiskWriteIops,
-			prometheus.GaugeValue,
-			diskWriteIops,
-			diskLabels...,
-		)
+		if len(metrics.TimeSeries["disk.0.bandwidth.read"]) > 0 {
+			diskReadBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.read"][len(metrics.TimeSeries["disk.0.bandwidth.read"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskReadBps,
+				prometheus.GaugeValue,
+				diskReadBps,
+				diskLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.DiskReadBps,
-			prometheus.GaugeValue,
-			diskReadBps,
-			diskLabels...,
-		)
+		if len(metrics.TimeSeries["disk.0.bandwidth.write"]) > 0 {
+			diskWriteBps, _ := strconv.ParseFloat(metrics.TimeSeries["disk.0.bandwidth.write"][len(metrics.TimeSeries["disk.0.bandwidth.write"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.DiskWriteBps,
+				prometheus.GaugeValue,
+				diskWriteBps,
+				diskLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.DiskWriteBps,
-			prometheus.GaugeValue,
-			diskWriteBps,
-			diskLabels...,
-		)
+		if len(metrics.TimeSeries["network.0.pps.in"]) > 0 {
+			networkInPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.in"][len(metrics.TimeSeries["network.0.pps.in"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkInPps,
+				prometheus.GaugeValue,
+				networkInPps,
+				networkLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.NetworkInPps,
-			prometheus.GaugeValue,
-			networkInPps,
-			networkLabels...,
-		)
+		if len(metrics.TimeSeries["network.0.pps.out"]) > 0 {
+			networkOutPps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.pps.out"][len(metrics.TimeSeries["network.0.pps.out"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkOutPps,
+				prometheus.GaugeValue,
+				networkOutPps,
+				networkLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.NetworkOutPps,
-			prometheus.GaugeValue,
-			networkOutPps,
-			networkLabels...,
-		)
+		if len(metrics.TimeSeries["network.0.bandwidth.in"]) > 0 {
+			networkInBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.in"][len(metrics.TimeSeries["network.0.bandwidth.in"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkInBps,
+				prometheus.GaugeValue,
+				networkInBps,
+				networkLabels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.NetworkInBps,
-			prometheus.GaugeValue,
-			networkInBps,
-			networkLabels...,
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.NetworkOutBps,
-			prometheus.GaugeValue,
-			networkOutBps,
-			networkLabels...,
-		)
+		if len(metrics.TimeSeries["network.0.bandwidth.out"]) > 0 {
+			networkOutBps, _ := strconv.ParseFloat(metrics.TimeSeries["network.0.bandwidth.out"][len(metrics.TimeSeries["network.0.bandwidth.out"])-1].Value, 64)
+			ch <- prometheus.MustNewConstMetric(
+				c.NetworkOutBps,
+				prometheus.GaugeValue,
+				networkOutBps,
+				networkLabels...,
+			)
+		}
 	}
 
 	c.duration.WithLabelValues("server_metrics").Observe(time.Since(now).Seconds())


### PR DESCRIPTION
The code assumed there to always be a single metrics datapoint returned
from the API. In some cases this is not true though, and an index out of
range error would occur.

This code explicitly checks for at least one datapoint to be present,
and use the last returned datapoint. It should handle omitted datapoints
more gracefully.

Fixes #72 