### PR TITLE
Fix: get all servers when collecting server metrics

### DIFF
--- a/pkg/exporter/server_metrics.go
+++ b/pkg/exporter/server_metrics.go
@@ -147,7 +147,7 @@ func (c *ServerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	defer cancel()
 
 	now := time.Now()
-	servers, _, err := c.client.Server.List(ctx, hcloud.ServerListOpts{
+	servers, err := c.client.Server.AllWithOpts(ctx, hcloud.ServerListOpts{
 		Status: []hcloud.ServerStatus{
 			hcloud.ServerStatusRunning,
 		},


### PR DESCRIPTION
[Issue](https://github.com/promhippie/hcloud_exporter/issues/246)