### PR TITLE
fix: resolve the server name for volumes and floating IPs

### DIFF
--- a/pkg/exporter/floating_ip.go
+++ b/pkg/exporter/floating_ip.go
@@ -78,6 +78,20 @@ func (c *FloatingIPCollector) Collect(ch chan<- prometheus.Metric) {
 		"count", len(ips),
 	)
 
+	var names map[int64]string
+
+	for _, ip := range ips {
+		if ip.Server != nil && ip.Server.Name == "" {
+			if names, err = resolveServerNames(ctx, c.client); err != nil {
+				c.logger.Warn("Failed to resolve server names",
+					"err", err,
+				)
+			}
+
+			break
+		}
+	}
+
 	for _, ip := range ips {
 		var (
 			active float64
@@ -87,6 +101,10 @@ func (c *FloatingIPCollector) Collect(ch chan<- prometheus.Metric) {
 		if ip.Server != nil {
 			active = 1.0
 			name = ip.Server.Name
+
+			if name == "" {
+				name = names[ip.Server.ID]
+			}
 		}
 
 		labels := []string{

--- a/pkg/exporter/helper.go
+++ b/pkg/exporter/helper.go
@@ -1,9 +1,34 @@
 package exporter
 
+import (
+	"context"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
 func boolToFloat64(val bool) float64 {
 	if val {
 		return 1.0
 	}
 
 	return 0.0
+}
+
+// resolveServerNames maps server IDs to their names. The list endpoints for
+// volumes and floating IPs only embed the ID of the attached server, so the
+// name has to be looked up separately to fill the server label.
+func resolveServerNames(ctx context.Context, client *hcloud.Client) (map[int64]string, error) {
+	servers, err := client.Server.All(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	names := make(map[int64]string, len(servers))
+
+	for _, server := range servers {
+		names[server.ID] = server.Name
+	}
+
+	return names, nil
 }

--- a/pkg/exporter/volume.go
+++ b/pkg/exporter/volume.go
@@ -105,6 +105,20 @@ func (c *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 		"count", len(volumes),
 	)
 
+	var names map[int64]string
+
+	for _, volume := range volumes {
+		if volume.Server != nil && volume.Server.Name == "" {
+			if names, err = resolveServerNames(ctx, c.client); err != nil {
+				c.logger.Warn("Failed to resolve server names",
+					"err", err,
+				)
+			}
+
+			break
+		}
+	}
+
 	for _, volume := range volumes {
 		var (
 			status     float64
@@ -114,6 +128,10 @@ func (c *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if volume.Server != nil {
 			name = volume.Server.Name
+
+			if name == "" {
+				name = names[volume.Server.ID]
+			}
 		}
 
 		labels := []string{

--- a/pkg/exporter/volume_test.go
+++ b/pkg/exporter/volume_test.go
@@ -1,0 +1,145 @@
+package exporter
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/promhippie/hcloud_exporter/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The volumes endpoint embeds the attached server as a bare ID, so the name has
+// to come from the servers endpoint. Payloads trimmed from real API responses.
+const volumesPayload = `{
+  "volumes": [
+    {
+      "id": 1001,
+      "name": "attached-volume",
+      "server": 42,
+      "size": 10,
+      "status": "available",
+      "location": {"name": "nbg1"},
+      "protection": {"delete": false},
+      "created": "2024-01-01T00:00:00+00:00"
+    },
+    {
+      "id": 1002,
+      "name": "unattached-volume",
+      "server": null,
+      "size": 10,
+      "status": "available",
+      "location": {"name": "nbg1"},
+      "protection": {"delete": false},
+      "created": "2024-01-01T00:00:00+00:00"
+    }
+  ],
+  "meta": {"pagination": {"page": 1, "per_page": 50, "total_entries": 2}}
+}`
+
+const serversPayload = `{
+  "servers": [
+    {
+      "id": 42,
+      "name": "example-server",
+      "status": "running",
+      "datacenter": {"name": "nbg1-dc3"},
+      "server_type": {"name": "cx22", "cores": 2, "memory": 4, "disk": 40},
+      "created": "2024-01-01T00:00:00+00:00"
+    }
+  ],
+  "meta": {"pagination": {"page": 1, "per_page": 50, "total_entries": 1}}
+}`
+
+func volumeServerLabels(t *testing.T, handler http.HandlerFunc) map[string]string {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := hcloud.NewClient(
+		hcloud.WithEndpoint(server.URL),
+		hcloud.WithToken("token"),
+	)
+
+	collector := NewVolumeCollector(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		client,
+		prometheus.NewCounterVec(prometheus.CounterOpts{Name: "failures"}, []string{"collector"}),
+		prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "duration"}, []string{"collector"}),
+		config.Target{Timeout: 5 * time.Second},
+	)
+
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, registry.Register(collector))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	labels := make(map[string]string)
+
+	for _, family := range families {
+		if family.GetName() != "hcloud_volume_size" {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			var name, srv string
+
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "name":
+					name = label.GetValue()
+				case "server":
+					srv = label.GetValue()
+				}
+			}
+
+			labels[name] = srv
+		}
+	}
+
+	return labels
+}
+
+func TestVolumeCollectorResolvesServerName(t *testing.T) {
+	labels := volumeServerLabels(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/volumes":
+			_, _ = w.Write([]byte(volumesPayload))
+		case "/servers":
+			_, _ = w.Write([]byte(serversPayload))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	assert.Equal(t, "example-server", labels["attached-volume"],
+		"an attached volume should carry the name of its server")
+	assert.Empty(t, labels["unattached-volume"],
+		"an unattached volume should carry an empty server label")
+}
+
+func TestVolumeCollectorKeepsCollectingWhenServersFail(t *testing.T) {
+	labels := volumeServerLabels(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/volumes":
+			_, _ = w.Write([]byte(volumesPayload))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	assert.Len(t, labels, 2, "volume metrics should still be exported")
+	assert.Empty(t, labels["attached-volume"])
+}


### PR DESCRIPTION
### Problem

`hcloud_volume_*` and `hcloud_floating_ip_*` carry a `server` label that is meant
to hold the name of the attached server. In practice it is **always empty**,
whether the resource is attached or not, so it cannot be used to tell an attached
resource from a detached one.

### Reproduction

Two volumes in the same project, one attached to a server and one not. The API
distinguishes them cleanly:

```
GET https://api.hetzner.cloud/v1/volumes

test-exporter-attached     id=106812831  server=58174178
test-exporter-unattached   id=106812780  server=null
```

The exporter does not:

```
hcloud_volume_size{id="106812780",location="nbg1",name="test-exporter-unattached",server=""} 10
hcloud_volume_size{id="106812831",location="nbg1",name="test-exporter-attached",server=""} 10
```

The two rows differ only in id and name. Reproduced on v3.27.0, scraped straight
from the container, with the volumes collector enabled and no
`metric_relabel_configs` touching the label.

### Cause

The volumes and floating IPs list endpoints return `server` as a bare ID, so
`hcloud-go` builds `&Server{ID: ...}` and leaves `Name` empty:

```go
if volume.Server != nil {
    name = volume.Server.Name // always ""
}
```

`pkg/exporter/floating_ip.go` does the same with `ip.Server.Name`. The floating
IP collector at least exposes `hcloud_floating_ip_active`, so attachment is
observable there; volumes have no equivalent, which makes the empty label the
only signal there is.

### Fix

Resolve the IDs against the servers endpoint. The lookup happens once per scrape
and only when something is actually attached with a missing name, so accounts
with no attachments issue no extra request. A failed lookup is logged and leaves
the label empty instead of dropping the metrics.

### Tests

`pkg/exporter/volume_test.go` serves trimmed real payloads over `httptest` and
asserts that the attached volume carries its server name while the unattached one
stays empty, plus that volume metrics are still exported when the servers call
fails. The first test fails on `master`:

```
expected: "example-server"
actual  : ""
```

Happy to split this into an issue first, or to drop the floating IP half if you
would rather keep the change to a single collector.